### PR TITLE
Handle dynamic imports with no file extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,17 @@ async function replaceImports (fileContents: string, resolveDir: string, config:
 		} catch (e) {
 			console.error(e);
 		}
+
+		// For all files ending in '.js', also allow importing without the extension
+		const jsImportFilePaths = importFilePaths.filter(filePath => {
+			return /\.js$/.test(filePath);
+		});
+		importFilePaths = importFilePaths.concat(
+			jsImportFilePaths.map(jsFilePath => {
+				return jsFilePath.replace(/\.js$/, '');
+			})
+		);
+
 		if (importFilePaths.length === 0) {
 			return fileContents;
 		}


### PR DESCRIPTION
For every `.js` file in the import destination directory, this code adds a copy of the key that omits the file extension, and which will point to the same module in the final product. Note that to use the plugin for import statements without file extensions at all, the `transformExtensions` option needs to include an empty string.

Addresses #7.

Maybe it should be considered to add an option that enables this behavior. If the behavior should apply to file extensions other than `.js`, the option could include a list of file extensions that may be omitted, similar to `transformExtensions`.