### PR TITLE
Add check for existance of symbol to support rebundling by Webpack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ async function replaceImports (fileContents: string, resolveDir: string, config:
 		// remove the extra comma added and add the closing bracket and semicolon
 		objectMapString = objectMapString.replace(/.$/, '};');
 
-    const importFunctionString = `function _DynamicImport(path) {const mod=_DynamicImportModuleMap[path];mod[Symbol.toStringTag]='Module';return Promise.resolve(mod); }`;
+    	const importFunctionString = `function _DynamicImport(path) {const mod=_DynamicImportModuleMap[path];if(!mod[Symbol.toStringTag]) mod[Symbol.toStringTag]='Module';return Promise.resolve(mod); }`;
 
 		const jsStr = `${importString}\n${objectMapString}\n${importFunctionString}\n`;
 


### PR DESCRIPTION
When using esbuild to bundle an npm package for distribution in a registry, we want our package to be able to be bundled into another bundle by consuming projects. When we tried to consume an esbuild-bundled package in a nextjs project, we encountered an error where `mod[Symbol.toStringTag]` is already populated with an immutable value. This PR simply checks for that situation and leaves the value alone.